### PR TITLE
Update Sticker Transition to use a `customValue` for Sticker Packs.

### DIFF
--- a/data/stickerTransition.hx
+++ b/data/stickerTransition.hx
@@ -3,7 +3,7 @@ import funkin.backend.MusicBeatTransition;
 import haxe.io.Path;
 import StickerPack;
 
-public static var stickerPackID:String = "standard-pico";
+public static var defaultStickerPackID:String = "default";
 
 static var lastStickers:Array<{
 	var stickerPath:String;
@@ -24,7 +24,7 @@ var grpStickers:FlxGroup;
 var timerManager:FlxTimerManager;
 
 function create(event) {
-	stickerPack = new StickerPack(stickerPackID);
+	stickerPack = new StickerPack(PlayState.SONG.meta.customValues?.stickerPack ?? defaultStickerPackID);
 
 	grpStickers = new FlxGroup();
 	add(grpStickers);

--- a/songs/2hot/meta.json
+++ b/songs/2hot/meta.json
@@ -15,6 +15,7 @@
 	"beatsPerMeasure": 4,
 	"bpm": 182,
 	"customValues": {
+		"stickerPack": "bonus-weekend1",
 		"album": "volume4"
 	}
 }

--- a/songs/blazin/meta.json
+++ b/songs/blazin/meta.json
@@ -15,6 +15,7 @@
 	"beatsPerMeasure": 4,
 	"bpm": 180,
 	"customValues": {
+		"stickerPack": "bonus-weekend1",
 		"album": "volume4"
 	}
 }

--- a/songs/darnell/meta.json
+++ b/songs/darnell/meta.json
@@ -16,6 +16,7 @@
 	"name": "darnell",
 	"color": "#6162FF",
 	"customValues": {
+		"stickerPack": "bonus-weekend1",
 		"album": "volume4"
 	}
 }

--- a/songs/lit up/meta.json
+++ b/songs/lit up/meta.json
@@ -15,6 +15,7 @@
 	"beatsPerMeasure": 4,
 	"bpm": 176,
 	"customValues": {
+		"stickerPack": "bonus-weekend1",
 		"album": "volume4"
 	}
 }

--- a/songs/roses/meta.json
+++ b/songs/roses/meta.json
@@ -15,5 +15,8 @@
 	"displayName": "Roses",
 	"beatsPerMeasure": 4,
 	"needsVoices": true,
-	"bpm": 120
+	"bpm": 120,
+	"customValues": {
+		"stickerPack": "standard-bf"
+	}
 }

--- a/songs/senpai/meta.json
+++ b/songs/senpai/meta.json
@@ -15,5 +15,8 @@
 	"displayName": "Senpai",
 	"beatsPerMeasure": 4,
 	"needsVoices": true,
-	"bpm": 144
+	"bpm": 144,
+	"customValues": {
+		"stickerPack": "standard-bf"
+	}
 }


### PR DESCRIPTION
This PR updates the Sticker Transition Script to use a `customValue`, making it easier to change the sticker pack.