### PR TITLE
fix that fuckass rating

### DIFF
--- a/songs/vslice_uiShits.hx
+++ b/songs/vslice_uiShits.hx
@@ -26,7 +26,7 @@ function onNoteHit(event) {
     event.ratingScale -= ratingScaleDiff;
 }
 
-function update() 
+function postUpdate() 
     comboGroup.forEachAlive(function(spr) if (spr.camera != camHUD) spr.camera = camHUD);
 
 function postUpdate(elapsed:Float) {


### PR DESCRIPTION
So Basic Summary
(I Think) At High FPS The Rating Is On camGame for a few frames, that would be fine, if it didnt jump so fucking far when it appears on hud, idk why but changing when it gets set to camHUD (change it to postUpdate) fixes the issue, so please just accept this so its fixed and no longer is annoying